### PR TITLE
HOTFIX: Resolve Oro 5.0.3 compatibility issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "oro/commerce": "~5.0.0"
+    "oro/commerce": "~5.0.3"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "oro/commerce": "~5.0.3"
+    "oro/commerce": "~5.0.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",

--- a/src/Aligent/FeesBundle/Fee/Provider/FeeProviderRegistry.php
+++ b/src/Aligent/FeesBundle/Fee/Provider/FeeProviderRegistry.php
@@ -44,7 +44,7 @@ class FeeProviderRegistry
     public function getProviders(?string $type = null): array
     {
         if ($type) {
-            return $this->providersByType[$type];
+            return $this->providersByType[$type] ?? [];
         }
 
         return $this->providers;

--- a/src/Aligent/FeesBundle/Resources/config/services.yml
+++ b/src/Aligent/FeesBundle/Resources/config/services.yml
@@ -33,3 +33,9 @@ services:
         decoration_inner_name: 'oro_tax.order_tax.context_handler.order_line_item_handler.inner'
         calls:
             - ['setConfigManager', ['@oro_config.manager']]
+
+    Aligent\FeesBundle\WorkflowState\Mapper\ShoppingListLineItemDiffMapperDecorator:
+        parent: oro_checkout.workflow_state.mapper.shopping_list_line_item
+        decorates: oro_checkout.workflow_state.mapper.shopping_list_line_item
+        calls:
+            - ['setInnerMapper', ['@Aligent\FeesBundle\WorkflowState\Mapper\ShoppingListLineItemDiffMapperDecorator.inner']]

--- a/src/Aligent/FeesBundle/Tests/Unit/Fee/Provider/FeeProviderRegistryTest.php
+++ b/src/Aligent/FeesBundle/Tests/Unit/Fee/Provider/FeeProviderRegistryTest.php
@@ -14,6 +14,22 @@ use Aligent\FeesBundle\Fee\Provider\FeeProviderRegistry;
 
 class FeeProviderRegistryTest extends \PHPUnit\Framework\TestCase
 {
+    public function testEmptyProviderCanBeQueried(): void
+    {
+        $registry = new FeeProviderRegistry();
+
+        // Confirm no fees yet
+        $this->assertEmpty($registry->getProviders());
+
+        // Try to load fees by Type, ensure this fails gracefully
+        $this->assertEmpty($registry->getProviders(FeeProviderInterface::TYPE_LINE_ITEM));
+        $this->assertEmpty($registry->getProviders(FeeProviderInterface::TYPE_SUBTOTAL));
+
+        // Accessing a specific non-existent Fee should result in an exception
+        $this->expectExceptionMessage('Fee with name "fee_1" does not exist');
+        $registry->getProvider('fee_1');
+    }
+
     public function testProvidersCanBeAddedAndAccessed(): void
     {
         /**
@@ -33,17 +49,8 @@ class FeeProviderRegistryTest extends \PHPUnit\Framework\TestCase
         $feeProvider2->expects($this->any())->method('getType')
             ->willReturn(FeeProviderInterface::TYPE_LINE_ITEM);
 
-
+        // Add both fees to Registry
         $registry = new FeeProviderRegistry();
-
-        // Confirm no fees yet
-        $this->assertEmpty($registry->getProviders());
-
-        // Accessing a non-existent Fee should result in an exception
-        $this->expectExceptionMessage('Fee with name "fee_1" does not exist');
-        $registry->getProvider('fee_1');
-
-        // Add both fees
         $registry->addProvider($feeProvider1);
         $registry->addProvider($feeProvider2);
 
@@ -54,6 +61,10 @@ class FeeProviderRegistryTest extends \PHPUnit\Framework\TestCase
         // Confirm we can also retrieve them individually by name
         $this->assertSame($feeProvider1, $registry->getProvider('fee_1'));
         $this->assertSame($feeProvider2, $registry->getProvider('fee_2'));
+
+        // Confirm we can also load them by Type
+        $this->assertCount(2, $registry->getProviders(FeeProviderInterface::TYPE_LINE_ITEM));
+        $this->assertCount(0, $registry->getProviders(FeeProviderInterface::TYPE_SUBTOTAL));
     }
 
     public function testFeesCannotBeRegisteredTwice(): void

--- a/src/Aligent/FeesBundle/Tests/Unit/WorkflowState/Mapper/ShoppingListLineItemDiffMapperDecoratorTest.php
+++ b/src/Aligent/FeesBundle/Tests/Unit/WorkflowState/Mapper/ShoppingListLineItemDiffMapperDecoratorTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * @category  Aligent
+ * @package
+ * @author    Chris Rossi <chris.rossi@aligent.com.au>
+ * @copyright 2022 Aligent Consulting.
+ * @license
+ * @link      http://www.aligent.com.au/
+ */
+namespace Aligent\FeesBundle\Tests\Unit\WorkflowState\Mapper;
+
+use Aligent\FeesBundle\WorkflowState\Mapper\ShoppingListLineItemDiffMapperDecorator;
+use Oro\Bundle\CheckoutBundle\Entity\Checkout;
+use Oro\Bundle\CheckoutBundle\Entity\CheckoutLineItem;
+use Oro\Bundle\CheckoutBundle\Provider\CheckoutShippingContextProvider;
+use Oro\Bundle\CheckoutBundle\WorkflowState\Mapper\ShoppingListLineItemDiffMapper;
+use Oro\Bundle\ConfigBundle\Config\ConfigManager;
+use Oro\Bundle\ProductBundle\Entity\Product;
+use Oro\Component\Testing\Unit\EntityTrait;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ShoppingListLineItemDiffMapperDecoratorTest extends \PHPUnit\Framework\TestCase
+{
+    use EntityTrait;
+
+    protected MockObject|ShoppingListLineItemDiffMapper $innerMapper;
+    protected ConfigManager|MockObject $configManager;
+    protected MockObject|CheckoutShippingContextProvider $shipContextProvider;
+
+    protected function setUp(): void
+    {
+        $this->configManager = $this->createMock(ConfigManager::class);
+        $this->shipContextProvider = $this->createMock(CheckoutShippingContextProvider::class);
+
+        $this->innerMapper = $this->getMockBuilder(ShoppingListLineItemDiffMapper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getCurrentState'])
+            ->getMock();
+
+        // A default/mock value that the innerMapper will return if it is ever called
+        $this->innerMapper->expects($this->any())
+            ->method('getCurrentState')
+            ->willReturn(['CURRENT_STATE']);
+    }
+
+    /**
+     * @dataProvider lineItemsProvider
+     * @param array<array<string,mixed>> $lineItemsData
+     * @param array<string>|null $expectedCurrentState
+     * @return void
+     */
+    public function testCurrentStateIsReturnedCorrectly(array $lineItemsData, ?array $expectedCurrentState): void
+    {
+        $decoratedMapper = new ShoppingListLineItemDiffMapperDecorator(
+            $this->configManager,
+            $this->shipContextProvider
+        );
+
+        $decoratedMapper->setInnerMapper($this->innerMapper);
+
+        $checkout = $this->getEntity(Checkout::class, [
+            'id' => 123,
+        ]);
+
+        foreach ($lineItemsData as $lineItemsDatum) {
+            $lineItem = $this->getEntity(CheckoutLineItem::class, $lineItemsDatum);
+            $checkout->addLineItem($lineItem);
+        }
+
+        $currentState = $decoratedMapper->getCurrentState($checkout);
+
+        $this->assertEquals($expectedCurrentState, $currentState);
+    }
+
+    public function lineItemsProvider(): \Generator
+    {
+        yield 'No Freeform Line Items returns array' => [
+            'lineItemsData' => [
+                [
+                    'id' => 1,
+                    'product' => $this->getEntity(Product::class, [
+                        'id' => 20,
+                        'sku' => 'ABC123',
+                    ])
+                ],
+                [
+                    'id' => 2,
+                    'product' => $this->getEntity(Product::class, [
+                        'id' => 30,
+                        'sku' => 'XYZ321',
+                    ])
+                ],
+            ],
+            'expectedCurrentState' => ['CURRENT_STATE'],
+        ];
+
+        yield 'One or more Freeform Line Items returns null' => [
+            'lineItemsData' => [
+                [
+                    'id' => 1,
+                    'product' => $this->getEntity(Product::class, [
+                        'id' => 20,
+                        'sku' => 'ABC123',
+                    ])
+                ],
+                [
+                    'id' => 2,
+                    'product' => null,
+                    'freeFormProduct' => 'FREEFORM-1',
+                ],
+            ],
+            'expectedCurrentState' => null,
+        ];
+
+        yield 'Multiple Freeform Line Items returns null' => [
+            'lineItemsData' => [
+                [
+                    'id' => 1,
+                    'product' => null,
+                    'freeFormProduct' => 'FREEFORM-1',
+                ],
+                [
+                    'id' => 2,
+                    'product' => null,
+                    'freeFormProduct' => 'FREEFORM-2',
+                ],
+            ],
+            'expectedCurrentState' => null,
+        ];
+    }
+}

--- a/src/Aligent/FeesBundle/WorkflowState/Mapper/ShoppingListLineItemDiffMapperDecorator.php
+++ b/src/Aligent/FeesBundle/WorkflowState/Mapper/ShoppingListLineItemDiffMapperDecorator.php
@@ -52,7 +52,7 @@ class ShoppingListLineItemDiffMapperDecorator extends ShoppingListLineItemDiffMa
     }
 
     /**
-     * Determine if $entity contains Freeform LineItems
+     * Determine if entity contains Freeform LineItems
      * (ie LineItems without a Product)
      */
     protected function entityContainsFreeformLineItems(mixed $entity): bool

--- a/src/Aligent/FeesBundle/WorkflowState/Mapper/ShoppingListLineItemDiffMapperDecorator.php
+++ b/src/Aligent/FeesBundle/WorkflowState/Mapper/ShoppingListLineItemDiffMapperDecorator.php
@@ -35,10 +35,10 @@ class ShoppingListLineItemDiffMapperDecorator extends ShoppingListLineItemDiffMa
     }
 
     /**
-     * @param $entity
+     * @param mixed $entity
      * @return array<string>|null
      */
-    public function getCurrentState($entity): ?array
+    public function getCurrentState(mixed $entity): ?array
     {
         if ($this->entityContainsFreeformLineItems($entity)) {
             /**
@@ -52,7 +52,7 @@ class ShoppingListLineItemDiffMapperDecorator extends ShoppingListLineItemDiffMa
     }
 
     /**
-     * Determine if entity contains Freeform LineItems
+     * Determine if $entity contains Freeform LineItems
      * (ie LineItems without a Product)
      */
     protected function entityContainsFreeformLineItems(mixed $entity): bool

--- a/src/Aligent/FeesBundle/WorkflowState/Mapper/ShoppingListLineItemDiffMapperDecorator.php
+++ b/src/Aligent/FeesBundle/WorkflowState/Mapper/ShoppingListLineItemDiffMapperDecorator.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * @category  Aligent
+ * @package
+ * @author    Chris Rossi <chris.rossi@aligent.com.au>
+ * @copyright 2022 Aligent Consulting.
+ * @license
+ * @link      http://www.aligent.com.au/
+ */
+namespace Aligent\FeesBundle\WorkflowState\Mapper;
+
+use Oro\Bundle\CheckoutBundle\Entity\Checkout;
+use Oro\Bundle\CheckoutBundle\WorkflowState\Mapper\CheckoutStateDiffMapperInterface;
+use Oro\Bundle\CheckoutBundle\WorkflowState\Mapper\ShoppingListLineItemDiffMapper;
+
+/**
+ * Decorate the \Oro\Bundle\CheckoutBundle\WorkflowState\Mapper\ShoppingListLineItemDiffMapper
+ * added in OroCommerce 5.0.3 as this breaks LineItem Fees.
+ *
+ * The ShoppingListLineItemDiffMapper assumes that Checkout Line Items which were converted
+ * from ShoppingList Line Items do not contain FreeForm Line Items, however our Bundle
+ * may have injected those as Line Item Fees.
+ * This causes fatal errors when attempting to access properties of a null object
+ * (ie $item->getProduct()->getSkuUppercase() when $item->getProduct() returns null).
+ *
+ * NOTE: WE need to extend the ShoppingListLineItemDiffMapper as Oro expects an instance of this specific class.
+ */
+class ShoppingListLineItemDiffMapperDecorator extends ShoppingListLineItemDiffMapper
+{
+    protected CheckoutStateDiffMapperInterface $innerMapper;
+
+    public function setInnerMapper(CheckoutStateDiffMapperInterface $innerMapper): void
+    {
+        $this->innerMapper = $innerMapper;
+    }
+
+    /**
+     * @param $entity
+     * @return array<string>|null
+     */
+    public function getCurrentState($entity): ?array
+    {
+        if ($this->entityContainsFreeformLineItems($entity)) {
+            /**
+             * If Entity contains Freeform Line Items, return null so that a new Checkout is started
+             * (and ShoppingListLineItemDiffMapper::getCurrentState is skipped).
+             */
+            return null;
+        }
+
+        return $this->innerMapper->getCurrentState($entity);
+    }
+
+    /**
+     * Determine if $entity contains Freeform LineItems
+     * (ie LineItems without a Product)
+     */
+    protected function entityContainsFreeformLineItems(mixed $entity): bool
+    {
+        if (!$entity instanceof Checkout) {
+            return false;
+        }
+
+        foreach ($entity->getLineItems() as $lineItem) {
+            // ProductHolderInterface incorrectly presumes that getProduct() is not nullable
+            // @phpstan-ignore-next-line
+            if (!$lineItem->getProduct()) {
+                // This LineItem has no Product
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function isEntitySupported($entity): bool
+    {
+        return $this->innerMapper->isEntitySupported($entity);
+    }
+
+    public function getName(): string
+    {
+        return $this->innerMapper->getName();
+    }
+
+    public function isStatesEqual($entity, $state1, $state2): bool
+    {
+        return $this->innerMapper->isStatesEqual($entity, $state1, $state2);
+    }
+}


### PR DESCRIPTION
Fix compatibility with `ShoppingListLineItemDiffMapper` added in Oro `5.0.3`

Resolves https://github.com/aligent/orocommerce-fees-bundle/issues/8
    
* Decorate `ShoppingListLineItemDiffMapper` to skip checks if Checkout contains Freeform Line items
* Add unit tests for `ShoppingListLineItemDiffMapperDecorator`
* Fix unreliable unit tests for `FeeProviderRegistry`
* Fix bug in `FeeProvider::getProviders` when loading by `$type` which does not exist
* Lock minimum Oro version to `5.0.3`
