### PR TITLE
Block PayPal Processing Fees

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ For example, if a 'Handling Fee' is to be charged for orders under $100.
 This Bundle takes advantage of OroCommerce's 'Freeform LineItem' feature,
 where a LineItem can be added to the Checkout without being linked to a Product.
 
+It also supports Fees added as Subtotals against the entire Order.
+
 Requirements
 -------------------
 - OroCommerce 5.0
@@ -74,7 +76,10 @@ If the Customer chooses that method during the Checkout, a processing fee will b
 
 <img src="src/Aligent/FeesBundle/Resources/doc/img/processing-fees-subtotal.png" alt="Processing Fees Subtotal">
 
-**NOTE: Processing Fees are not currently support by PayPal Express as they are not included in the Subtotal, which causes a payment validation error**
+**NOTE: Processing Fees are not currently support by PayPal Express as they are not included in the Subtotal, which causes a payment validation error.**
+
+Additionally, the [PayPal User Agreement](https://www.paypal.com/us/webapps/mpp/ua/useragreement-full) does not allow charging Payment Processing Fees (See [#13](https://github.com/aligent/orocommerce-fees-bundle/issues/13))
+
 
 ### Adding and Registering new Custom Fees
 1. Create a new Bundle (or use an existing one as needed)
@@ -172,8 +177,8 @@ Roadmap / Remaining Tasks
 - [x] Implement Unit Tests
 - [x] Complete adding support for Fees added as Subtotals
 - [x] Add Native Support for Payment Processing Fees
-- [ ] Add support for PayPal Express Processing Fees
+- [x] ~~Add support for PayPal Express Processing Fees~~ (See [#13](https://github.com/aligent/orocommerce-fees-bundle/issues/13))
 - [ ] Re-implement support for line item messaging
 - [ ] Convert Product Tax Code Configuration into Select field
-- [ ] More fine-grained control over Processing Fees (eg exclude certain Customer Groups from being charged fee)
+- [ ] More fine-grained control over Processing Fees (e.g. exclude certain Customer Groups from being charged fee)
 - [ ] (TBC) Add support for Expression Language

--- a/src/Aligent/FeesBundle/Form/Type/ProcessingFeeCollectionType.php
+++ b/src/Aligent/FeesBundle/Form/Type/ProcessingFeeCollectionType.php
@@ -22,6 +22,19 @@ class ProcessingFeeCollectionType extends AbstractType
 {
     const NAME = 'aligent_processing_fee_collection';
 
+    /**
+     * Methods which are not allowed/supported, either for technical reasons
+     * or because Processing Fees are against their User Agreement.
+     *
+     * NOTE: Method class names must be declared as strings here in case
+     *       payment method bundle has not been installed.
+     */
+    const DISALLOWED_METHODS = [
+        'Oro\Bundle\PayPalExpressBundle\Method\PayPalExpressMethod',
+        'Oro\Bundle\PayPalBundle\Method\PayPalCreditCardPaymentMethod',
+        'Oro\Bundle\PayPalBundle\Method\PayPalExpressCheckoutPaymentMethod',
+    ];
+
     protected PaymentMethodProviderInterface $methodProvider;
     protected PaymentMethodViewProviderInterface $methodViewProvider;
 
@@ -84,6 +97,11 @@ class ProcessingFeeCollectionType extends AbstractType
     {
         $result = [];
         foreach ($this->methodProvider->getPaymentMethods() as $method) {
+            if (in_array(get_class($method), self::DISALLOWED_METHODS)) {
+                // Skip disallowed methods (e.g. PayPal)
+                continue;
+            }
+
             $methodId = $method->getIdentifier();
             $label = $this
                 ->methodViewProvider->getPaymentMethodView($methodId)

--- a/src/Aligent/FeesBundle/Resources/config/oro/system_configuration.yml
+++ b/src/Aligent/FeesBundle/Resources/config/oro/system_configuration.yml
@@ -26,6 +26,7 @@ system_configuration:
             type: Aligent\FeesBundle\Form\Type\ProcessingFeeCollectionType
             options:
                 label: aligent.fees.configuration.aligent_fees.processing_fee.fields.payment_methods.label
+                tooltip: aligent.fees.configuration.aligent_fees.processing_fee.fields.payment_methods.tooltip
     tree:
         system_configuration:
             commerce:

--- a/src/Aligent/FeesBundle/Resources/translations/messages.en.yml
+++ b/src/Aligent/FeesBundle/Resources/translations/messages.en.yml
@@ -12,11 +12,14 @@ aligent:
                     segment_title.label: 'Processing Fees'
                     fields:
                         enabled.label: 'Enable Processing Fees'
-                        payment_methods.label: 'Enable for Payment Methods (NOTE: PayPal Express is NOT Supported!)'
+                        payment_methods:
+                            label: 'Enable for Payment Methods (NOTE: PayPal is NOT Supported!)'
+                            tooltip: |
+                                The PayPal User Agreement does not allow charging processing fees for PayPal Payments<br><br>
+                                See https://github.com/aligent/orocommerce-fees-bundle/issues/13
                         method.label: 'Payment Method'
                         percentage.label: 'Processing Fee Percentage'
 
         checkout:
             subtotal:
                 processing_fee.label: 'Payment Processing Fee'
-


### PR DESCRIPTION
PayPal does not allow Payment Processing Fees in their User Agreement.
Resolves #13 

* Update README to explain PayPal Processing Fees are not supported
* Hide PayPal methods in Configuration UI (defined in ProcessingFeeCollectionType)
* Minor documentation/translation updates

**Before:**
![2022-07-27_10-55](https://user-images.githubusercontent.com/45612883/181142731-c4fd15bb-2cac-4910-b967-38b3a1b8ec9b.png)
**After:**
![2022-07-27_11-05](https://user-images.githubusercontent.com/45612883/181142741-3d32d159-d906-4fd5-834a-57a45156b6b5.png)
