### PR TITLE
Implement Line Item Fee Messaging

### DIFF
--- a/src/Aligent/FeesBundle/EventListener/CreateCheckoutListener.php
+++ b/src/Aligent/FeesBundle/EventListener/CreateCheckoutListener.php
@@ -13,8 +13,8 @@
  */
 namespace Aligent\FeesBundle\EventListener;
 
-use Aligent\FeesBundle\Fee\Provider\FeeProviderRegistry;
 use Aligent\FeesBundle\Fee\Provider\FeeProviderInterface;
+use Aligent\FeesBundle\Fee\Provider\FeeProviderRegistry;
 use Aligent\FeesBundle\Fee\Provider\LineItemFeeProviderInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Oro\Bundle\ActionBundle\Model\ActionData;

--- a/src/Aligent/FeesBundle/EventListener/LineItemFeeMessageListener.php
+++ b/src/Aligent/FeesBundle/EventListener/LineItemFeeMessageListener.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @category  Aligent
+ * @package
+ * @author    Chris Rossi <chris.rossi@aligent.com.au>
+ * @copyright 2022 Aligent Consulting.
+ * @license
+ * @link      http://www.aligent.com.au/
+ */
+namespace Aligent\FeesBundle\EventListener;
+
+use Aligent\FeesBundle\Fee\Provider\FeeProviderInterface;
+use Aligent\FeesBundle\Fee\Provider\FeeProviderRegistry;
+use Aligent\FeesBundle\Fee\Provider\LineItemFeeProviderInterface;
+use Oro\Bundle\CheckoutBundle\Entity\Checkout;
+use Oro\Bundle\ShoppingListBundle\Event\LineItemValidateEvent;
+use Oro\Bundle\WorkflowBundle\Entity\WorkflowItem;
+
+class LineItemFeeMessageListener
+{
+    protected FeeProviderRegistry $feeProviderRegistry;
+
+    public const ALLOWED_STEPS = [
+        'order_review' => true,
+        'checkout' => true,
+        'enter_billing_address' => true,
+        'enter_shipping_address' => true,
+        'enter_shipping_method' => true,
+        'enter_payment' => true
+    ];
+
+    public function __construct(
+        FeeProviderRegistry $feeProviderRegistry
+    ) {
+        $this->feeProviderRegistry = $feeProviderRegistry;
+    }
+
+    /**
+     * Called when validating a LineItem
+     */
+    public function onLineItemValidate(LineItemValidateEvent $event): void
+    {
+        $context = $event->getContext();
+
+        if (!$this->isContextSupported($context)) {
+            // The ShoppingList has no Context, exclude it
+            return;
+        }
+
+        /** @var Checkout $checkout */
+        $checkout = $context->getEntity();
+
+        foreach ($this->feeProviderRegistry->getProviders(FeeProviderInterface::TYPE_LINE_ITEM) as $feeProvider) {
+            if (!$feeProvider instanceof LineItemFeeProviderInterface) {
+                continue;
+            }
+
+            foreach ($feeProvider->getMessages($checkout) as $feeMessage) {
+                $event->addWarningByUnit(
+                    $feeMessage->getProductSku(),
+                    $feeMessage->getProductUnitCode(),
+                    $feeMessage->getMessage()
+                );
+            }
+        }
+    }
+
+    protected function isContextSupported(mixed $context): bool
+    {
+        return $context instanceof WorkflowItem
+            && $context->getEntity() instanceof Checkout
+            && !empty(self::ALLOWED_STEPS[$context->getCurrentStep()->getName()]);
+    }
+}

--- a/src/Aligent/FeesBundle/Fee/Factory/CheckoutLineItemFeeFactory.php
+++ b/src/Aligent/FeesBundle/Fee/Factory/CheckoutLineItemFeeFactory.php
@@ -58,7 +58,8 @@ class CheckoutLineItemFeeFactory
             ->setFreeFormProduct($feeLineItemDTO->getLabel()) // Must be a Free Form product
             ->setProductSku($feeLineItemDTO->getProductSku())
             ->setProductUnit($productUnit)
-            ->setProductUnitCode($productUnit->getCode());
+            ->setProductUnitCode($productUnit->getCode())
+        ;
 
         return $lineItem;
     }

--- a/src/Aligent/FeesBundle/Fee/Model/FeeLineItemDTO.php
+++ b/src/Aligent/FeesBundle/Fee/Model/FeeLineItemDTO.php
@@ -18,13 +18,14 @@ class FeeLineItemDTO
     protected ?string $productSku = null;
     protected ?string $productUnitCode = null;
     protected ?string $label = null;
+    protected ?string $message = null;
 
     public function getAmount(): ?float
     {
         return $this->amount;
     }
 
-    public function setAmount(float $amount): FeeLineItemDTO
+    public function setAmount(float $amount): static
     {
         $this->amount = $amount;
         return $this;
@@ -35,7 +36,7 @@ class FeeLineItemDTO
         return $this->currency;
     }
 
-    public function setCurrency(string $currency): FeeLineItemDTO
+    public function setCurrency(string $currency): static
     {
         $this->currency = $currency;
         return $this;
@@ -46,7 +47,7 @@ class FeeLineItemDTO
         return $this->productSku;
     }
 
-    public function setProductSku(string $productSku): FeeLineItemDTO
+    public function setProductSku(string $productSku): static
     {
         $this->productSku = $productSku;
         return $this;
@@ -57,7 +58,7 @@ class FeeLineItemDTO
         return $this->productUnitCode;
     }
 
-    public function setProductUnitCode(string $productUnitCode): FeeLineItemDTO
+    public function setProductUnitCode(string $productUnitCode): static
     {
         $this->productUnitCode = $productUnitCode;
         return $this;
@@ -68,7 +69,7 @@ class FeeLineItemDTO
         return $this->label;
     }
 
-    public function setLabel(string $label): FeeLineItemDTO
+    public function setLabel(string $label): static
     {
         $this->label = $label;
         return $this;
@@ -84,5 +85,21 @@ class FeeLineItemDTO
             (string)$this->getAmount(),
             $this->getCurrency()
         );
+    }
+
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+
+    public function hasMessage(): bool
+    {
+        return (bool)$this->message;
+    }
+
+    public function setMessage(?string $message): static
+    {
+        $this->message = $message;
+        return $this;
     }
 }

--- a/src/Aligent/FeesBundle/Fee/Provider/FeeProviderInterface.php
+++ b/src/Aligent/FeesBundle/Fee/Provider/FeeProviderInterface.php
@@ -9,8 +9,6 @@
  */
 namespace Aligent\FeesBundle\Fee\Provider;
 
-use Oro\Bundle\CheckoutBundle\Entity\Checkout;
-
 /**
  * NOTE: This interface should not be used directly, instead extend one of the Abstract Fee providers.
  */

--- a/src/Aligent/FeesBundle/Fee/Provider/LineItemFeeProviderInterface.php
+++ b/src/Aligent/FeesBundle/Fee/Provider/LineItemFeeProviderInterface.php
@@ -26,5 +26,11 @@ interface LineItemFeeProviderInterface extends FeeProviderInterface
     /**
      * @return array<FeeLineItemDTO>
      */
-    public function buildFees(Checkout $checkout): array;
+    public function getFeeLineItems(Checkout $checkout): array;
+
+    /**
+     * @param Checkout $checkout
+     * @return array<FeeLineItemDTO>
+     */
+    public function getMessages(Checkout $checkout): array;
 }

--- a/src/Aligent/FeesBundle/Fee/Provider/SubtotalFeeProviderInterface.php
+++ b/src/Aligent/FeesBundle/Fee/Provider/SubtotalFeeProviderInterface.php
@@ -9,9 +9,6 @@
  */
 namespace Aligent\FeesBundle\Fee\Provider;
 
-use Aligent\FeesBundle\Fee\Model\FeeLineItemDTO;
-use Oro\Bundle\CheckoutBundle\Entity\Checkout;
-use Oro\Bundle\CheckoutBundle\Entity\CheckoutLineItem;
 use Oro\Bundle\PricingBundle\SubtotalProcessor\Model\SubtotalProviderInterface;
 
 /**

--- a/src/Aligent/FeesBundle/Resources/config/services.yml
+++ b/src/Aligent/FeesBundle/Resources/config/services.yml
@@ -57,6 +57,12 @@ services:
         tags:
             - { name: kernel.event_listener, event: extendable_condition.start_checkout, method: onStartCheckoutConditionCheck }
 
+    Aligent\FeesBundle\EventListener\LineItemFeeMessageListener:
+        arguments:
+            - '@aligent_fees.fee_provider_registry'
+        tags:
+            - { name: kernel.event_listener, event: line_item.validate, method: onLineItemValidate, priority: 10 }
+
     # Decorate Oro Order Tax Handler to support Freeform Line Items
     Aligent\FeesBundle\ContextHandler\FreeFormAwareTaxOrderLineItemHandler:
         parent: oro_tax.order_tax.context_handler.order_line_item_handler

--- a/src/Aligent/FeesBundle/Tests/Unit/EventListener/LineItemFeeMessageListenerTest.php
+++ b/src/Aligent/FeesBundle/Tests/Unit/EventListener/LineItemFeeMessageListenerTest.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * @category  Aligent
+ * @package
+ * @author    Chris Rossi <chris.rossi@aligent.com.au>
+ * @copyright 2022 Aligent Consulting.
+ * @license
+ * @link      http://www.aligent.com.au/
+ */
+namespace Aligent\FeesBundle\Tests\Unit\EventListener;
+
+use Aligent\FeesBundle\EventListener\LineItemFeeMessageListener;
+use Aligent\FeesBundle\Fee\Model\FeeLineItemDTO;
+use Aligent\FeesBundle\Fee\Provider\AbstractLineItemFeeProvider;
+use Aligent\FeesBundle\Fee\Provider\FeeProviderRegistry;
+use Doctrine\Common\Collections\ArrayCollection;
+use Iterator;
+use Oro\Bundle\CheckoutBundle\Entity\Checkout;
+use Oro\Bundle\ProductBundle\Entity\Product;
+use Oro\Bundle\ShoppingListBundle\Entity\LineItem;
+use Oro\Bundle\ShoppingListBundle\Event\LineItemValidateEvent;
+use Oro\Bundle\WorkflowBundle\Entity\WorkflowItem;
+use Oro\Bundle\WorkflowBundle\Entity\WorkflowStep;
+use Oro\Bundle\WorkflowBundle\Exception\WorkflowException;
+use Oro\Component\Testing\Unit\EntityTrait;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class LineItemFeeMessageListenerTest extends \PHPUnit\Framework\TestCase
+{
+    use EntityTrait;
+
+    protected MockObject|FeeProviderRegistry $feeProviderRegistry;
+
+    protected function setUp(): void
+    {
+        $this->feeProviderRegistry = $this->getMockBuilder(FeeProviderRegistry::class)
+            ->onlyMethods(['getProviders'])
+            ->getMock();
+    }
+
+    /**
+     * @dataProvider getContextData
+     */
+    public function testOnlyCheckoutIsSupported(mixed $context, int $expectedCallCount): void
+    {
+        $listener = new LineItemFeeMessageListener($this->feeProviderRegistry);
+
+        $lineItems = [$this->getEntity(LineItem::class)];
+
+        $this->feeProviderRegistry->expects($this->exactly($expectedCallCount))
+            ->method('getProviders');
+
+        $event = new LineItemValidateEvent($lineItems, $context);
+        $listener->onLineItemValidate($event);
+    }
+
+    /**
+     * @throws WorkflowException
+     * @return Iterator<string,mixed>
+     */
+    public function getContextData(): Iterator
+    {
+        yield 'Invalid Context' => [
+            'context' => [],
+            'expectedCallCount' => 0,
+        ];
+
+        $context = new WorkflowItem();
+        $context->setEntity($this->getEntity(Product::class));
+        yield 'Invalid Entity' => [
+            'context' => $context,
+            'expectedCallCount' => 0,
+        ];
+
+        $context = new WorkflowItem();
+        $context->setEntity($this->getEntity(Checkout::class));
+        $context->setCurrentStep($this->getEntity(WorkflowStep::class, [
+            'name' => 'payment_fail',
+        ]));
+        yield 'Valid Entity & Invalid Step' => [
+            'context' => $context,
+            'expectedCallCount' => 0,
+        ];
+
+        $context = new WorkflowItem();
+        $context->setEntity($this->getEntity(Checkout::class));
+        $context->setCurrentStep($this->getEntity(WorkflowStep::class, [
+            'name' => 'enter_billing_address',
+        ]));
+        yield 'Valid Entity & Step' => [
+            'context' => $context,
+            'expectedCallCount' => 1, // Provider should be called once
+        ];
+    }
+
+    /**
+     * @dataProvider getWarningMessageData
+     * @param array<FeeLineItemDTO> $feeLineItemDTOs
+     * @param ArrayCollection<string,string> $expectedWarnings
+     * @return void
+     * @throws WorkflowException
+     */
+    public function testWarningMessagesAreAdded(array $feeLineItemDTOs, ArrayCollection $expectedWarnings): void
+    {
+        $context = new WorkflowItem();
+        $context->setEntity($this->getEntity(Checkout::class));
+        $context->setCurrentStep($this->getEntity(WorkflowStep::class, [
+            'name' => 'order_review',
+        ]));
+
+        $listener = new LineItemFeeMessageListener($this->feeProviderRegistry);
+
+        $lineItems = [$this->getEntity(LineItem::class)];
+
+        $feeProvider = $this->getMockBuilder(AbstractLineItemFeeProvider::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getMessages'])
+            ->getMockForAbstractClass();
+
+        $feeProvider->expects($this->once())
+            ->method('getMessages')
+            ->willReturn($feeLineItemDTOs);
+
+        $this->feeProviderRegistry->expects($this->exactly(1))
+            ->method('getProviders')
+            ->willReturn([$feeProvider]);
+
+        $event = new LineItemValidateEvent($lineItems, $context);
+        $listener->onLineItemValidate($event);
+
+        $this->assertFalse($event->hasErrors());
+        $this->assertCount(count($expectedWarnings), $event->getWarnings());
+        $this->assertEquals($expectedWarnings, $event->getWarnings());
+        $this->assertEquals((count($expectedWarnings) > 0), $event->hasWarnings());
+    }
+
+    public function getWarningMessageData(): Iterator
+    {
+        yield 'No Warning Messages' => [
+            'feeLineItemDTOs' => [],
+            'expectedWarnings' => new ArrayCollection([]),
+        ];
+
+        yield 'One Warning Message' => [
+            'feeLineItemDTOs' => [
+                (new FeeLineItemDTO())
+                    ->setProductSku('FEE-1')
+                    ->setProductUnitCode('each')
+                    ->setMessage('Fee is applied 1'),
+            ],
+            'expectedWarnings' => new ArrayCollection([
+                [
+                    'sku' => 'FEE-1',
+                    'unit' => 'each',
+                    'message' => 'Fee is applied 1',
+                ],
+            ]),
+        ];
+
+        yield 'Multiple Warning Messages' => [
+            'feeLineItemDTOs' => [
+                (new FeeLineItemDTO())
+                    ->setProductSku('FEE-2')
+                    ->setProductUnitCode('each')
+                    ->setMessage('Fee is applied 2'),
+                (new FeeLineItemDTO())
+                    ->setProductSku('FEE-3')
+                    ->setProductUnitCode('item')
+                    ->setMessage('Fee is applied 3'),
+            ],
+            'expectedWarnings' => new ArrayCollection([
+                [
+                    'sku' => 'FEE-2',
+                    'unit' => 'each',
+                    'message' => 'Fee is applied 2',
+                ],
+                [
+                    'sku' => 'FEE-3',
+                    'unit' => 'item',
+                    'message' => 'Fee is applied 3',
+                ],
+            ]),
+        ];
+    }
+}

--- a/src/Aligent/FeesBundle/Tests/Unit/Fee/Factory/CheckoutLineItemFeeFactoryTest.php
+++ b/src/Aligent/FeesBundle/Tests/Unit/Fee/Factory/CheckoutLineItemFeeFactoryTest.php
@@ -68,7 +68,6 @@ class CheckoutLineItemFeeFactoryTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expectedLineItemData['productUnitCode'], $lineItem->getProductUnit()->getCode());
         $this->assertEquals($expectedLineItemData['productUnitCode'], $lineItem->getProductUnitCode());
 
-
         $this->assertInstanceOf(Price::class, $lineItem->getPrice());
         $this->assertEquals($expectedLineItemData['amount'], $lineItem->getPrice()->getValue());
         $this->assertEquals($expectedLineItemData['currency'], $lineItem->getPrice()->getCurrency());
@@ -137,7 +136,7 @@ class CheckoutLineItemFeeFactoryTest extends \PHPUnit\Framework\TestCase
     {
         yield 'Test Multiple Fees' => [
             'feeConfigData' => [
-                'handling Fee 1' => [
+                'Handling Fee 1' => [
                     'currency' => 'USD',
                     'amount' => 123.45,
                     'label' => 'Handling Fee 1',

--- a/src/Aligent/FeesBundle/Tests/Unit/Fee/Model/FeeLineItemDTOTest.php
+++ b/src/Aligent/FeesBundle/Tests/Unit/Fee/Model/FeeLineItemDTOTest.php
@@ -23,6 +23,8 @@ class FeeLineItemDTOTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($object->getProductUnitCode());
         $this->assertNull($object->getAmount());
         $this->assertNull($object->getLabel());
+        $this->assertFalse($object->hasMessage());
+        $this->assertNull($object->getMessage());
 
         $object
             ->setProductSku('ABC123')
@@ -37,11 +39,18 @@ class FeeLineItemDTOTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('each', $object->getProductUnitCode());
         $this->assertEquals(123.45, $object->getAmount());
         $this->assertEquals('Shipping Fee', $object->getLabel());
+        $this->assertFalse($object->hasMessage());
+        $this->assertNull($object->getMessage());
 
         $this->assertInstanceOf(Price::class, $object->getPrice());
         $price = $object->getPrice();
         $this->assertEquals(123.45, $price->getValue());
         $this->assertEquals('USD', $price->getCurrency());
+
+        $object->setMessage('This is a test');
+
+        $this->assertTrue($object->hasMessage());
+        $this->assertEquals('This is a test', $object->getMessage());
     }
 
     public function testPriceIsOnlyCreatedWithValidData(): void


### PR DESCRIPTION
Resolves #17 

* Add `LineItemFeeMessageListener` to inject messages into Checkout line items
* Update `FeeLineItemDTO` to support Fee Messages
* Refactor `AbstractLineItemFeeProvider` to prevent duplicate buildFees() call
* Update `LineItemFeeProviderInterface` to reflect new methods
* Add unit tests for `LineItemFeeMessageListener`
* Update unit tests for `FeeLineItemDTO`
* Update unit tests for `AbstractLineItemFeeProvider`
* Minor code quality improvements

## Screenshots
![2022-08-10_13-38](https://user-images.githubusercontent.com/45612883/184055715-dd7892d2-1820-4ca2-a1f2-f3aa023dd18e.png)

![2022-08-10_13-39](https://user-images.githubusercontent.com/45612883/184055710-833481ad-3560-41e6-b11a-68ae00d19b91.png)
