### PR TITLE
Hotfix/oro 6.1 compat fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "oro/commerce": "~5.0.6"
+    "oro/commerce": "6.1.*"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",

--- a/src/Aligent/FeesBundle/ContextHandler/FreeFormAwareTaxOrderLineItemHandler.php
+++ b/src/Aligent/FeesBundle/ContextHandler/FreeFormAwareTaxOrderLineItemHandler.php
@@ -16,7 +16,7 @@ namespace Aligent\FeesBundle\ContextHandler;
 
 use Aligent\FeesBundle\DependencyInjection\Configuration;
 use Oro\Bundle\ConfigBundle\Config\ConfigManager;
-use Oro\Bundle\OrderBundle\Entity\OrderLineItem;
+use Oro\Bundle\OrderBundle\Entity\OrderHolderInterface;
 use Oro\Bundle\ProductBundle\Entity\Product;
 use Oro\Bundle\TaxBundle\Model\TaxCodeInterface;
 use Oro\Bundle\TaxBundle\OrderTax\ContextHandler\OrderLineItemHandler;
@@ -34,7 +34,7 @@ class FreeFormAwareTaxOrderLineItemHandler extends OrderLineItemHandler
      * NOTE: The parent getProductTaxCode method says it returns an instance of TaxCodeInterface
      *       when in reality it returns a string (ie TaxCodeInterface::getCode()).
      */
-    protected function getProductTaxCode(OrderLineItem $lineItem): ?string
+    protected function getProductTaxCode(OrderHolderInterface $lineItem): ?string
     {
         $taxCode = parent::getProductTaxCode($lineItem);
 

--- a/src/Aligent/FeesBundle/EventListener/CreateCheckoutListener.php
+++ b/src/Aligent/FeesBundle/EventListener/CreateCheckoutListener.php
@@ -32,13 +32,12 @@ class CreateCheckoutListener
         $this->managerRegistry = $registry;
     }
 
-    public function onStartCheckoutConditionCheck(ExtendableConditionEvent $event): bool
+    public function onStartCheckoutConditionCheck(ExtendableConditionEvent $event): void
     {
-        /** @var ActionData<string,mixed> $context */
-        $context = $event->getContext();
-
-        /** @var Checkout $checkout */
-        $checkout = $context->get('checkout');
+        $checkout = $event->getData()?->offsetGet('checkout');
+        if (!$checkout instanceof Checkout) {
+            return;
+        }
 
         $needsFlush = false;
 
@@ -71,7 +70,5 @@ class CreateCheckoutListener
             $manager->persist($checkout);
             $manager->flush();
         }
-
-        return true;
     }
 }


### PR DESCRIPTION
**Description of the proposed changes**

- Fix `FreeFormAwareTaxOrderLineItemHandler::getProductTaxCode` method signature —
  parent changed parameter type to `OrderHolderInterface` in Oro 6.1; incompatible
  override causes PHP Fatal Error in PHP 8.1+, breaking order tax/subtotal display
- Fix `CreateCheckoutListener` — `ExtendableConditionEvent::getContext()` replaced
  by `getData()` in Oro 6.1; checkout was unresolvable, preventing line item fee injection
- Bump `composer.json` requirement to `oro/commerce: 6.1.*`

⚠️ Please make sure the changes adhere to the guidelines mentioned in our [contribution guide](https://github.com/aligent/code-of-conduct/blob/main/CONTRIBUTING.md).

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

