### PR TITLE
GIA-712: Fix PaymentProcessingFee not appearing at checkout in OroCommerce 6.1

### DIFF
--- a/src/Aligent/FeesBundle/Fee/Provider/AbstractSubtotalFeeProvider.php
+++ b/src/Aligent/FeesBundle/Fee/Provider/AbstractSubtotalFeeProvider.php
@@ -40,16 +40,10 @@ abstract class AbstractSubtotalFeeProvider extends AbstractSubtotalProvider impl
     /**
      * @throws InvalidRoundingTypeException
      */
-    public function getSubtotal($entity): ?Subtotal
+    public function getSubtotal($entity): Subtotal
     {
         if (!$this->isSupported($entity)) {
             throw new \InvalidArgumentException('Entity not supported for provider');
-        }
-
-        $fee = $this->getFeeAmount($entity);
-
-        if ($fee === null) {
-            return null;
         }
 
         $subtotal = new Subtotal();
@@ -57,11 +51,17 @@ abstract class AbstractSubtotalFeeProvider extends AbstractSubtotalProvider impl
             ->setType($this->getName())
             ->setSortOrder($this->getSortOrder())
             ->setLabel($this->getFeeLabel())
-            ->setVisible(true)
-            ->setCurrency($this->getBaseCurrency($entity))
-            ->setAmount($this->rounding->round($fee));
+            ->setCurrency($this->getBaseCurrency($entity));
 
-        return $subtotal;
+        $fee = $this->getFeeAmount($entity);
+
+        if ($fee === null) {
+            return $subtotal->setVisible(false)->setAmount(0.0);
+        }
+
+        return $subtotal
+            ->setVisible(true)
+            ->setAmount($this->rounding->round($fee));
     }
 
     abstract protected function getFeeAmount(mixed $entity): ?float;

--- a/src/Aligent/FeesBundle/Fee/Provider/PaymentProcessingFeeProvider.php
+++ b/src/Aligent/FeesBundle/Fee/Provider/PaymentProcessingFeeProvider.php
@@ -12,6 +12,8 @@ namespace Aligent\FeesBundle\Fee\Provider;
 use Aligent\FeesBundle\DependencyInjection\Configuration;
 use Brick\Math\BigDecimal;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Persistence\ManagerRegistry;
+use Oro\Bundle\CheckoutBundle\Entity\Checkout;
 use Oro\Bundle\CheckoutBundle\Payment\Method\EntityPaymentMethodsProvider;
 use Oro\Bundle\CurrencyBundle\Exception\InvalidRoundingTypeException;
 use Oro\Bundle\OrderBundle\Entity\Order;
@@ -27,12 +29,13 @@ class PaymentProcessingFeeProvider extends AbstractSubtotalFeeProvider
     protected EntityPaymentMethodsProvider $entityPaymentMethodsProvider;
     protected SubtotalProviderRegistry $subtotalProviderRegistry;
     protected TotalProcessorProvider $totalProcessorProvider;
+    protected ManagerRegistry $doctrine;
 
     protected bool $forceRecalculation = false;
 
     public function isSupported(mixed $entity): bool
     {
-        return $entity instanceof Order && method_exists($entity, 'getProcessingFee');
+        return $entity instanceof Order || $entity instanceof Checkout;
     }
 
     public function getName(): string
@@ -56,13 +59,18 @@ class PaymentProcessingFeeProvider extends AbstractSubtotalFeeProvider
             throw new \InvalidArgumentException('Entity not supported for provider');
         }
 
-        if ($entity->getId() && !$this->forceRecalculation) {
-            // Load fee from Entity (ie persisted against Order)
-            $fee = $entity->getProcessingFee();
-        } else {
-            // Calculate the fee and assign it back to the Entity
-            $fee = $this->calculateProcessingFee($entity);
-            $entity->setProcessingFee($fee);
+        if ($entity instanceof Order && $entity->getId() && !$this->forceRecalculation) {
+            // Load fee from persisted Order via Doctrine metadata
+            $persisted = $this->getOrderFieldValue($entity, 'processing_fee');
+            if ($persisted !== null) {
+                return (float) $persisted;
+            }
+        }
+
+        // Calculate the fee
+        $fee = $this->calculateProcessingFee($entity);
+        if ($entity instanceof Order) {
+            $this->setOrderFieldValue($entity, 'processing_fee', $fee);
         }
 
         return $fee;
@@ -159,11 +167,37 @@ class PaymentProcessingFeeProvider extends AbstractSubtotalFeeProvider
 
     protected function getPaymentMethod(object $entity): ?string
     {
+        if ($entity instanceof Checkout) {
+            return $entity->getPaymentMethod();
+        }
         if ($entity instanceof Order) {
             $paymentMethods = $this->entityPaymentMethodsProvider->getPaymentMethods($entity);
-            return current($paymentMethods);
+            return current($paymentMethods) ?: null;
         }
         return null;
+    }
+
+    private function getOrderFieldValue(Order $order, string $field): mixed
+    {
+        $em = $this->doctrine->getManagerForClass(Order::class);
+        if (!$em) {
+            return null;
+        }
+        return $em->getClassMetadata(Order::class)->getFieldValue($order, $field);
+    }
+
+    private function setOrderFieldValue(Order $order, string $field, mixed $value): void
+    {
+        $em = $this->doctrine->getManagerForClass(Order::class);
+        if (!$em) {
+            return;
+        }
+        $em->getClassMetadata(Order::class)->setFieldValue($order, $field, $value);
+    }
+
+    public function setDoctrine(ManagerRegistry $doctrine): void
+    {
+        $this->doctrine = $doctrine;
     }
 
     public function setForceRecalculation(bool $forceRecalculation): void

--- a/src/Aligent/FeesBundle/Resources/config/services.yml
+++ b/src/Aligent/FeesBundle/Resources/config/services.yml
@@ -34,6 +34,7 @@ services:
             - ['setEntityPaymentMethodsProvider', ['@oro_checkout.payment_methods_provider']]
             - ['setSubtotalProviderRegistry', ['@oro_pricing.subtotal_processor.subtotal_provider_registry']]
             - ['setTotalProcessorProvider', ['@oro_pricing.subtotal_processor.total_processor_provider']]
+            - ['setDoctrine', ['@doctrine']]
         tags:
             - { name: oro_pricing.subtotal_provider, alias: aligent_fees.subtotal_payment_processing_fee, priority: 5000 }
 


### PR DESCRIPTION
Four issues caused the fee to not appear/persist under Oro 6.1:

1. isSupported() only accepted Order — checkout totals use Checkout entity. Now accepts Order or Checkout.

2. getSubtotal() returned null when fee was not applicable. Oro 6.1's TotalProcessorProvider::getEntitySubtotals() wraps any non-array return (including null) in [$result] t
3. hen crashes on ->getType(). Now returns a Subtotal with visible=false and amount=0 following Oro's own pattern.

4. CheckoutTotalsProvider converts Checkout to a base new Order() (not the extended entity) before calling subtotal providers. The original method_exists($entity, 'getProcessingFee') check failed on the base class, silently skipping the fee. The guard is now in getFeeAmount() where the method is actually called.

5. Oro 6.1 no longer generates PHP getter/setter traits for entity extend fields. Replace method_exists-based access with Doctrine ClassMetadata getFieldValue/setFieldValue, injected via a new setDoctrine() setter.

**Screenshots (if applicable)**

I was able to place an order with the processing fee:

<img width="621" height="395" alt="image" src="https://github.com/user-attachments/assets/b273f109-cf6b-4bd2-ad59-5a75703cd344" />
<img width="1687" height="443" alt="image" src="https://github.com/user-attachments/assets/79cb6104-1520-419b-a780-9abd0f08e337" />
<img width="1689" height="444" alt="image" src="https://github.com/user-attachments/assets/a8156371-cd48-4c71-b506-86f18376b5cd" />

**Other solutions considered (if any)**

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned in our [contribution guide](https://github.com/aligent/code-of-conduct/blob/main/CONTRIBUTING.md).

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

